### PR TITLE
Fix ActivityCell performance during ListView scroll

### DIFF
--- a/src/BotFramework.UI.Forms/Views/ActivityView.cs
+++ b/src/BotFramework.UI.Forms/Views/ActivityView.cs
@@ -103,14 +103,7 @@ namespace BotFramework.UI
 
 		protected virtual void ResetView ()
 		{
-			if(Frame.Content != null)
-				Frame.Content = null;
-		}
-
-		protected override void OnChildMeasureInvalidated ()
-		{
-			base.OnChildMeasureInvalidated ();
-			ParentCell?.ForceUpdateSize ();
+			Frame.Content = null;
 		}
 
 	}


### PR DESCRIPTION
- remove `ActivityCell.OnChildMeasureInvalidated` to avoid extra calls on ListView scroll, which internally calls `ParentCell?.ForceUpdateSize()` which during a scroll triggers `OnChildMeasureInvalidated` again and causes ListView to freeze temporarily or sometime even app to hang
- remove redundant null check at `ActivityCell.ResetView`