### PR TITLE
Update Activity ViewCell Size on Attachment Size Change

### DIFF
--- a/samples/BotChatForms/BotChatForms/BotChatPage.xaml.cs
+++ b/samples/BotChatForms/BotChatForms/BotChatPage.xaml.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Specialized;
+using System.Linq;
 using System.Threading.Tasks;
 using Xamarin.Forms;
 using System.Collections;
@@ -49,18 +51,29 @@ namespace BotChatForms
 			currentConversation = await ConversationManager.StartConversation (name, "djdOSzcO3dY.cwA.vbU.S2mx6ruLXxMlGQ2FnBcoXOcr9-sAJouXeDZH8JhbA58");
 			currentConversation.CardActionTapped = HandleCardActionTapped;
 			MessageList.ItemsSource = currentConversation.Conversation.Messages;
+            currentConversation.Conversation.Messages.CollectionChanged += Messages_CollectionChanged;
 			StartStopButton.Text = "End Conversation";
 		}
 
-		void HandleCardActionTapped (CardAction action)
-		{
-			switch (action.Type) {
-			case CardActionType.OpenUrl:
-				Device.OpenUri (new Uri (action.Value));
-				break;
-			}
-			Debug.WriteLine ($"Unhandled tap: {action.Value}");
-		}
+        void Messages_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        {
+            var lastItem = currentConversation.Conversation.Messages.LastOrDefault();
+            if (lastItem != null)
+                Device.BeginInvokeOnMainThread(() => MessageList.ScrollTo(lastItem, ScrollToPosition.Start, true));
+        }
+
+        void HandleCardActionTapped(CardAction action)
+        {
+            switch (action.Type)
+            {
+                case CardActionType.OpenUrl:
+                    Device.OpenUri(new Uri(action.Value));
+                    break;
+                default:
+                    Debug.WriteLine($"Unhandled tap: {action.Value}");
+                    break;
+            }
+        }
 
 		void Handle_ItemTapped(object sender, Xamarin.Forms.ItemTappedEventArgs e)
 		{

--- a/src/BotFramework.UI.Forms/Views/ActivityView.cs
+++ b/src/BotFramework.UI.Forms/Views/ActivityView.cs
@@ -4,14 +4,6 @@ using Xamarin.Forms;
 
 namespace BotFramework.UI
 {
-    public class ActivityViewCell : ViewCell
-	{
-		public ActivityViewCell ()
-		{
-			View = new ActivityView { ParentCell = this };
-		}
-	}
-    
     public class ActivityView : ContentView
 	{
 		WeakReference parentCell;
@@ -88,8 +80,11 @@ namespace BotFramework.UI
 			var view = ActivityTemplate?.CreateContent (activity,this) as View ?? new Label ();
 
 			var messageView = view as IMessageContext;
-			if (messageView != null)
-				messageView.IsFromMe = activity.IsFromMe;
+            if (messageView != null)
+            {
+                messageView.IsFromMe = activity.IsFromMe;
+                messageView.HostingCell = ParentCell;
+            }
 
 			view.BindingContext = activity;
 			

--- a/src/BotFramework.UI.Forms/Views/ActivityViewCell.cs
+++ b/src/BotFramework.UI.Forms/Views/ActivityViewCell.cs
@@ -1,0 +1,12 @@
+﻿using Xamarin.Forms;
+
+namespace BotFramework.UI
+{
+    public class ActivityViewCell : ViewCell
+    {
+        public ActivityViewCell()
+        {
+            View = new ActivityView { ParentCell = this };
+        }
+    }
+}

--- a/src/BotFramework.UI.Forms/Views/Cards/CardView.cs
+++ b/src/BotFramework.UI.Forms/Views/Cards/CardView.cs
@@ -17,6 +17,7 @@ namespace BotFramework.UI
 		}
 
 		public bool IsFromMe { get; set; }
+        public ViewCell HostingCell { get; set; }
 
 		protected virtual void SetupView ()
 		{

--- a/src/BotFramework.UI.Forms/Views/IMessageContext.cs
+++ b/src/BotFramework.UI.Forms/Views/IMessageContext.cs
@@ -1,8 +1,11 @@
 ﻿using System;
+using Xamarin.Forms;
+
 namespace BotFramework.UI
 {
 	public interface IMessageContext
 	{
 		bool IsFromMe { get; set; }
+        ViewCell HostingCell { get; set; }
 	}
 }

--- a/src/BotFramework.UI.Forms/Views/MessageView.cs
+++ b/src/BotFramework.UI.Forms/Views/MessageView.cs
@@ -15,6 +15,7 @@ namespace BotFramework.UI
 		}
 
 		public bool IsFromMe { get; set; }
+        public ViewCell HostingCell { get; set; }
 
 		Label Text;
 		public MessageView ()
@@ -37,18 +38,24 @@ namespace BotFramework.UI
 			if (message == null)
 				return;
 			Text.TextColor = IsFromMe ? Color.Black : Color.White;
-			if (message.Attachments != null)
-				foreach (var a in message.Attachments) {
-					Children.Add (CreateView (a));
-				}
+            if (message.Attachments != null)
+                foreach (var a in message.Attachments)
+                {
+                    var child = CreateView(a);
+                    child.SizeChanged += Child_SizeChanged;
+                    Children.Add(child);
+                }
 		}
 
 		protected virtual View CreateView (Attachment attachement)
 		{
 			var view = AttachmentTemplate?.CreateContent (attachement, this) as View ?? new Label ();
 			var messageView = view as IMessageContext;
-			if (messageView != null)
-				messageView.IsFromMe = IsFromMe;
+            if (messageView != null)
+            {
+                messageView.IsFromMe = IsFromMe;
+                messageView.HostingCell = HostingCell;
+            }
 
 			view.BindingContext = attachement;
 			return view;
@@ -56,7 +63,15 @@ namespace BotFramework.UI
 
 		protected virtual void ResetView ()
 		{
+            foreach (var childView in Children)
+                childView.SizeChanged -= Child_SizeChanged;
+
 			Children.Clear ();
 		}
+
+        private void Child_SizeChanged(object sender, EventArgs e)
+        {
+            HostingCell?.ForceUpdateSize();
+        }
 	}
 }


### PR DESCRIPTION
In this PR:
1. [SDK] In order to fix the issue with the dynamic content, we need to track whenever an attachment view size changes and trigger the hosting ViewCell size update. I'm passing it via `IMessageContext` interface to keep track of the hosting ViewCell inside Attachment Child View control.

2. [SDK] Moved the ActivityViewCell class to a separate file
3. [Samples] Scroll ListView on every received activity